### PR TITLE
made an authorisation hoc wrapper

### DIFF
--- a/frontend/src/components/AuthWrapper.js
+++ b/frontend/src/components/AuthWrapper.js
@@ -1,0 +1,83 @@
+import React, {Component} from "react";
+import {authTest_request, get_role} from "../utils/API";
+import {authActions} from "../utils/store";
+import connect from "react-redux/lib/connect/connect";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+// use this HOC wrapper around components that require authentication and authorisation to access
+// WrappedComponent is the function/class/component you wish to protect
+// role is a string that is either "commissioner" or "voter"
+// if you wish to protect, say, create party, then you you use the role "commissioner" as it is commissioner only
+
+export function withAuthorisation(WrappedComponent, role) {
+    class AuthWrapper extends Component {
+        constructor(props) {
+            super(props);
+            this.checkAuth = this.checkAuth.bind(this);
+            this.checkRole = this.checkRole.bind(this);
+            this.state ={
+                authenticated: false,
+                authorisation: false,
+                loadingAuthentication: true,
+                loadingAuthorisation: true,
+            }
+        };
+
+        componentWillMount() {
+            this.checkAuth();
+            this.checkRole();
+        }
+
+        checkAuth(){
+            authTest_request()
+                .catch(err => {
+                    this.props.logout();
+                    this.setState({authenticated: false, loadingAuthentication: false});
+                }).then(r => {
+                    if(r && r.status && r.status === 200){
+                        this.props.login();
+                        this.setState({authenticated: true, loadingAuthentication: false});
+                    }
+            });
+
+        }
+
+        checkRole(){
+            get_role()
+                .catch(err => {
+                    this.setState({authorisation: false, loadingAuthorisation: false});
+                }).then(r => {
+                    if(r && r.status && r.status === 200){
+                        this.setState({authorisation: r.data, loadingAuthorisation: false});
+                    }
+                });
+
+        }
+
+        render() {
+            if(this.state.loadingAuthorisation || this.state.loadingAuthentication){
+                return <><h1>loading...</h1><CircularProgress size="72px"/></>;
+            }
+            if(this.state.authenticated && this.state.authorisation === role){
+                return <WrappedComponent {...this.props} />;
+            }else if(this.state.authenticated === false){
+                return <h1>Something went wrong. Please login</h1>;
+            }else{
+                return <h1>Forbidden!</h1>;
+            }
+
+        };
+    };
+
+    const mapDispatchToProps = (dispatch) => ({
+        logout: () => dispatch(authActions.logout()),
+        login: () => dispatch(authActions.login()),
+    });
+
+    const mapStateToProps = (state) => ({
+        isLoggedIn: state.authReducer.isLoggedIn,
+    });
+
+    return connect(mapStateToProps, mapDispatchToProps)(AuthWrapper);
+}
+

--- a/frontend/src/login/login.js
+++ b/frontend/src/login/login.js
@@ -55,7 +55,7 @@ class loginPage extends Component {
 
     render() {
         if (this.state.isPageLoading) {
-            return null;
+            return <><h1>loading...</h1><CircularProgress size="72px"/></>;
         }
         return (
             <>

--- a/frontend/src/navigation/NavigationTopBar.js
+++ b/frontend/src/navigation/NavigationTopBar.js
@@ -69,7 +69,20 @@ const useStyles = makeStyles((theme: Theme) =>
                 opacity: "0.8",
                 backgroundColor: primaryColor,
             },
-
+        },
+        logoutButton: {
+            textTransform: "none",
+            fontSize: "14px",
+            color: "white",
+            fontWeight: "bold",
+            opacity: 1,
+            backgroundColor: "red",
+            '&:hover': {
+                color: "white",
+                fontWeight: "bold",
+                opacity: "0.8",
+                backgroundColor: "red",
+            },
         },
 
     })
@@ -102,7 +115,7 @@ function LogoutAvatar(props) {
   return (
       <ThemeProvider theme={theme}>
           <div className={classes.leftTab}>
-              <Button className={classes.loginButton} onClick={() => logout(props)}>Log out</Button>
+              <Button className={classes.logoutButton} onClick={() => logout(props)}>Log out</Button>
           </div>
       </ThemeProvider>
   );

--- a/frontend/src/utils/API.js
+++ b/frontend/src/utils/API.js
@@ -4,6 +4,7 @@ const BaseUrl = "http://127.0.0.1:5000";
 const loginAPI = "/auth/login"; // POST
 const logoutAPI= "/auth/logout"; // [POST, GET]
 const authTestAPI= "/auth/test"; // GET
+const getRoleAPI = "/auth/get-role"; // GET
 
 
 // post API request for login
@@ -14,18 +15,25 @@ export async function login_request(username, password) {
         {headers:{"Content-Type": "application/json"}}
         );
     console.log(response);
-    return response.data
+    return response.data;
 }
 
 // post API request for logout
 export async function logout_request() {
     const response = await axios.get(logoutAPI);
-    return response.status
+    return response.status;
 }
 
 
 // post API request for logout
-export async function authTest_request(token) {
+export async function authTest_request() {
     const response = await axios.get(authTestAPI);
-    return response.status
+    return response;
+}
+
+// get API request for authorisation
+export async function get_role() {
+    const response = await axios.get(getRoleAPI);
+    console.log(response)
+    return response;
 }


### PR DESCRIPTION
You can now use the withAuthorisation to wrap around component which gates UI access to components. of course backend still needs to validate any actual requests, but we will display an error at the frontend if users try to access certain pages.

how to use:
to make a component commissioner only:
export default withAuthorisation(thecomponent, "commissioner");
